### PR TITLE
Introduce new parameter 'persistenceInfoLocation'

### DIFF
--- a/src/main/resources/empty-persistence.xml
+++ b/src/main/resources/empty-persistence.xml
@@ -4,6 +4,7 @@
 	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
 	version="2.1">
 	<persistence-unit name="" transaction-type="RESOURCE_LOCAL">
+		<provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
 		<properties>
 			<property name="eclipselink.weaving" value="static" />
 		</properties>


### PR DESCRIPTION
- Introduce new parameter 'persistenceInfoLocation' to define the location of the persistence.xml file. This is needed to create a WAR archive without the persistence.xml. Spring for example is capable of setting up the persistenceUnit without persistence.xml. The value of this parameter is simply forwarded to the StaticWeaver of EclipseLink.

- Defined the provider in persistence.xml. Otherwise JEE container like Wildfly will fall back to their default Hibernate.

- Repaired the 'prefix' parameter and renamed it to 'basePackage'