### PR TITLE
Add drop script parameter and configuration to handle it.

### DIFF
--- a/src/main/java/com/ethlo/persistence/tools/eclipselink/EclipselinkDdlGenerationMojo.java
+++ b/src/main/java/com/ethlo/persistence/tools/eclipselink/EclipselinkDdlGenerationMojo.java
@@ -21,7 +21,6 @@ package com.ethlo.persistence.tools.eclipselink;
  */
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.MalformedURLException;


### PR DESCRIPTION
For a lot of my work I need to generate both the create and drop script and track them in source control. This plugin was perfect to integrate into my existing maven build, but I needed it to create both scripts, not just the create script. So I coded it in.

Let me know if you see any issues or want a few tweaks. I can help!