### PR TITLE
Bump eclipselink version to 4.0.2 for JDK 21 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,7 @@
     </dependencies>
     <properties>
         <maven-version>3.8.1</maven-version>
-        <eclipselink-version>4.0.1</eclipselink-version>
+        <eclipselink-version>4.0.2</eclipselink-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <gpg.skip>true</gpg.skip>
     </properties>


### PR DESCRIPTION
EclipseLink version 4.0.2 added support for JDK 21: https://github.com/eclipse-ee4j/eclipselink/releases/tag/4.0.2

Closes #40 